### PR TITLE
Mahalanobis fix

### DIFF
--- a/aakr/_aakr.py
+++ b/aakr/_aakr.py
@@ -70,10 +70,23 @@ class AAKR(TransformerMixin, BaseEstimator):
 
     def _rbf_kernel(self, X_obs_nc, X_obs):
         # Kernel regression
-        D = pairwise_distances(X=X_obs_nc, Y=X_obs,
-                               metric=self.metric, n_jobs=self.n_jobs)
-        k = 1 / np.sqrt(2 * np.pi * self.bw ** 2)
-        w = k * np.exp(-D ** 2 / (2 * self.bw ** 2))
+        if self.metric == "mahalanobis":
+            D = pairwise_distances(
+                X=X_obs_nc,
+                Y=X_obs,
+                metric=self.metric,
+                n_jobs=self.n_jobs,
+                VI=np.linalg.inv(np.cov(X_obs_nc.T)).T,
+            )
+        else:
+            D = pairwise_distances(
+                X=X_obs_nc,
+                Y=X_obs,
+                metric=self.metric,
+                n_jobs=self.n_jobs,
+            )
+        k = 1 / np.sqrt(2 * np.pi * self.bw**2)
+        w = k * np.exp(-(D**2) / (2 * self.bw**2))
 
         return w
 

--- a/aakr/_aakr.py
+++ b/aakr/_aakr.py
@@ -45,8 +45,10 @@ class AAKR(TransformerMixin, BaseEstimator):
            signal reconstruction in nuclear power plant components", European
            Safety and Reliability Conference ESREL.
     """
-    def __init__(self, metric='euclidean', bw=1., modified=False, penalty=None,
-                 n_jobs=-1):
+
+    def __init__(
+        self, metric="euclidean", bw=1.0, modified=False, penalty=None, n_jobs=-1
+    ):
         self.metric = metric
         self.bw = bw
         self.modified = modified
@@ -60,13 +62,17 @@ class AAKR(TransformerMixin, BaseEstimator):
             if self.penalty is not None:
                 penalty = check_array(self.penalty, ensure_2d=False)
                 if len(penalty) != X.shape[1]:
-                    raise ValueError('Shape of input is different from what '
-                                     'is defined in penalty vector ('
-                                     f'{X.shape[1]} != {len(penalty)})')
+                    raise ValueError(
+                        "Shape of input is different from what "
+                        "is defined in penalty vector ("
+                        f"{X.shape[1]} != {len(penalty)})"
+                    )
         elif not self.modified and self.penalty is not None:
-            raise ValueError('Parameter `penalty` given, but `modified=False`.'
-                             'Please set `modified=True` to make use of the '
-                             'penalty vector, or set `penalty=None`.')
+            raise ValueError(
+                "Parameter `penalty` given, but `modified=False`."
+                "Please set `modified=True` to make use of the "
+                "penalty vector, or set `penalty=None`."
+            )
 
     def _rbf_kernel(self, X_obs_nc, X_obs):
         # Kernel regression
@@ -133,10 +139,12 @@ class AAKR(TransformerMixin, BaseEstimator):
         self._fit_validation(X)
 
         # Fit
-        if hasattr(self, 'X_'):
+        if hasattr(self, "X_"):
             if self.X_.shape[1] != X.shape[1]:
-                raise ValueError('Shape of input is different from what was '
-                                 'seen in `fit` or `partial_fit`')
+                raise ValueError(
+                    "Shape of input is different from what was "
+                    "seen in `fit` or `partial_fit`"
+                )
             self.X_ = np.vstack((self.X_, X))
         else:
             self.X_ = X
@@ -157,13 +165,14 @@ class AAKR(TransformerMixin, BaseEstimator):
             Expected values in normal conditions for each sample and feature.
         """
         # Validation
-        check_is_fitted(self, 'X_')
+        check_is_fitted(self, "X_")
 
         X = check_array(X)
 
         if X.shape[1] != self.X_.shape[1]:
-            raise ValueError('Shape of input is different from what was seen'
-                             'in `fit`')
+            raise ValueError(
+                "Shape of input is different from what was seen" "in `fit`"
+            )
 
         # Modified AAKR basically sorts the columns
         # TODO: Needs to be verified that everything here is correct
@@ -173,10 +182,10 @@ class AAKR(TransformerMixin, BaseEstimator):
 
             # Penalty matrix (J x J, where J is the number of features)
             if self.penalty is None:
-                D = np.diag(np.arange(X.shape[1]) + 1) ** 2.
+                D = np.diag(np.arange(X.shape[1]) + 1) ** 2.0
                 D /= D.sum()
             else:
-                D = np.diag(self.penalty).astype('float')
+                D = np.diag(self.penalty).astype("float")
 
             for i, X_obs in enumerate(X):  # TODO: Vectorize
                 # Standardized contributions in decreasing order (J, 1)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest==5.4.2
+pytest==6.2.5
 pytest-cov==2.10.1
 twine==3.2.0
 sphinx==3.3.1

--- a/tests/test_aakr.py
+++ b/tests/test_aakr.py
@@ -35,7 +35,6 @@ def test_euclidean_aakr(data):
     assert hasattr(aakr, "X_")
 
     X_nc = aakr.transform(X[:3])
-    X_nc.tofile("test.txt", sep=",")
     assert_allclose(X_nc, X[:3])
 
 

--- a/tests/test_aakr.py
+++ b/tests/test_aakr.py
@@ -18,17 +18,33 @@ def data():
     return load_linnerud(return_X_y=True)
 
 
-def test_aakr(data):
+def test_default_aakr(data):
     X = data[0]
     aakr = AAKR()
-    assert aakr.metric == 'euclidean'
+    assert aakr.metric == "euclidean"
     assert aakr.bw == 1
     assert not aakr.modified
     assert aakr.penalty is None
     assert aakr.n_jobs == -1
 
+
+def test_euclidean_aakr(data):
+    X = data[0]
+    aakr = AAKR()
     aakr.fit(X)
-    assert hasattr(aakr, 'X_')
+    assert hasattr(aakr, "X_")
+
+    X_nc = aakr.transform(X[:3])
+    X_nc.tofile("test.txt", sep=",")
+    assert_allclose(X_nc, X[:3])
+
+
+def test_mahalanobis_aakr(data):
+    X = data[0]
+    aakr = AAKR(bw=0.01, metric="mahalanobis")
+
+    aakr.fit(X)
+    assert hasattr(aakr, "X_")
 
     X_nc = aakr.transform(X[:3])
     assert_allclose(X_nc, X[:3])
@@ -39,7 +55,7 @@ def test_aakr_fit_input_shape_mismatch(data):
     aakr = AAKR().fit(X)
     assert aakr.X_.shape[1] == X.shape[1]
 
-    with pytest.raises(ValueError, match='Shape of input is different'):
+    with pytest.raises(ValueError, match="Shape of input is different"):
         aakr.transform(X[:3, :-1])
 
 
@@ -48,7 +64,7 @@ def test_aakr_partial_fit_input_shape_mismatch(data):
     aakr = AAKR().partial_fit(X)
     assert aakr.X_.shape[1] == X.shape[1]
 
-    with pytest.raises(ValueError, match='Shape of input is different'):
+    with pytest.raises(ValueError, match="Shape of input is different"):
         aakr.partial_fit(X[:, :-1])
 
 
@@ -58,19 +74,19 @@ def test_aakr_modified(data):
     # Modified, no penalty given
     aakr = AAKR(modified=True, penalty=None)
     X_nc = aakr.fit(X).transform(X[:3])
-    assert hasattr(aakr, 'X_')
-    assert_allclose(X_nc, X[:3], atol=1.)
+    assert hasattr(aakr, "X_")
+    assert_allclose(X_nc, X[:3], atol=1.0)
 
     # Modified, penalty given
     aakr = AAKR(modified=True, penalty=[1] * X.shape[1])
     X_nc = aakr.fit(X).transform(X[:3])
-    assert hasattr(aakr, 'X_')
-    assert_allclose(X_nc, X[:3], atol=1.)
+    assert hasattr(aakr, "X_")
+    assert_allclose(X_nc, X[:3], atol=1.0)
 
     # Modified, penalty given, mismatch with input data
-    with pytest.raises(ValueError, match='Shape of input is different from'):
+    with pytest.raises(ValueError, match="Shape of input is different from"):
         AAKR(modified=True, penalty=[1] * (X.shape[1] - 1)).fit(X)
 
     # No modified, penalty given
-    with pytest.raises(ValueError, match='Parameter `penalty` given, but'):
+    with pytest.raises(ValueError, match="Parameter `penalty` given, but"):
         AAKR(modified=False, penalty=[1] * X.shape[1]).fit(X)


### PR DESCRIPTION
Mahalanobis distance couldn't be used as a metric since it required the VI kwarg to be passed to the sklearn `pairwise_distance` function (that is the inverse of the covariance matrix between the fitted elements).

I also added tests for the mahalanobis case. To make the test work in newer Python version I had to bump `pytest` to a newer version.

I also fromatted the file with `black` to standardize line width.